### PR TITLE
feat(docs): Add illustrative image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 >
 > What's even better than twice cooked fries is triple cooked fries!
 
-![Refry basic usage example](https://github.com/rjvitorino/refry/assets/2514072/25118d3a-8192-43fc-8bf5-24fce6798606)
+![Refry basic usage example](https://github.com/pydanny/refry/assets/2514072/939ecaf7-c1de-4864-b1c8-24907197bb73)
 
 Refry is a modern, maintained, typed easy-to-use retry decorator.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 >
 > What's even better than twice cooked fries is triple cooked fries!
 
+![Refry basic usage example](https://github.com/rjvitorino/refry/assets/2514072/25118d3a-8192-43fc-8bf5-24fce6798606)
+
 Refry is a modern, maintained, typed easy-to-use retry decorator.
 
 ---


### PR DESCRIPTION
Added an illustrative image to the README file to provide a visual example of using the 'refry' retry decorator. This image enhances the documentation by showing upfront a code snippet demonstrating the decorator's action. Updated the README to include this visual aid for better user understanding.